### PR TITLE
Add router format

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -27,39 +27,7 @@
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExeDir Condition=" Exists('$(PaketBootStrapperExePath)') " >$([System.IO.Path]::GetDirectoryName("$(PaketBootStrapperExePath)"))\</PaketBootStrapperExeDir>
-
-    <!-- Paket -->
-
-    <!-- windows, root => tool => proj style => bootstrapper => global -->
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket.exe</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketBootStrapperExeDir)') ">$(_PaketBootStrapperExeDir)paket.exe</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' ">paket.exe</PaketExePath>
-
-    <!-- no windows, try native paket as default,  root => tool => proj style => mono paket => bootstrpper => global -->
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketRootPath)paket') ">$(PaketRootPath)paket</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketToolsPath)paket') ">$(PaketToolsPath)paket</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket</PaketExePath>
-
-    <!-- no windows, try mono paket -->
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
-
-    <!-- no windows, try bootstrapper -->
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketBootStrapperExeDir)') ">$(PaketBootStrapperExeDir)paket.exe</PaketExePath>
-
-    <!-- no windows, try global native paket -->
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' ">paket</PaketExePath>
-
-    <!-- Paket command -->
-    <_PaketExeExtension>$([System.IO.Path]::GetExtension("$(PaketExePath)"))</_PaketExeExtension>
-    <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</PaketCommand>
-    <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(_PaketExeExtension)' == '' ">dotnet "$(PaketExePath)"</PaketCommand>
-    <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(OS)' != 'Windows_NT' AND '$(_PaketExeExtension)' == '.exe' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</PaketCommand>
-    <PaketCommand Condition=" '$(PaketCommand)' == '' ">"$(PaketExePath)"</PaketCommand>
-
-
+    
     <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
     <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
 
@@ -75,6 +43,57 @@
     <PaketIntermediateOutputPath Condition=" '$(PaketIntermediateOutputPath)' == '' ">$(BaseIntermediateOutputPath.TrimEnd('\').TrimEnd('\/'))</PaketIntermediateOutputPath>
   </PropertyGroup>
 
+  <!-- Check if paket is available as local dotnet cli tool -->
+  <Target Name="SetPaketCommand" >
+  
+    <!-- Call 'dotnet paket' and see if it returns without an error. Mute all the output. -->
+    <Exec Command="dotnet paket --version" IgnoreExitCode="true" StandardOutputImportance="low" StandardErrorImportance="low" >
+      <Output TaskParameter="ExitCode" PropertyName="LocalPaketToolExitCode" />
+    </Exec>
+
+    <!-- If local paket tool is found, use that -->
+    <PropertyGroup Condition=" '$(LocalPaketToolExitCode)' == '0' ">
+      <InternalPaketCommand>dotnet paket</InternalPaketCommand>
+    </PropertyGroup>
+
+    <!-- If not, then we go through our normal steps of setting the Paket command.  -->
+    <PropertyGroup Condition=" '$(LocalPaketToolExitCode)' != '0' ">
+      <!-- windows, root => tool => proj style => bootstrapper => global -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket.exe</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketBootStrapperExeDir)') ">$(_PaketBootStrapperExeDir)paket.exe</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' ">paket.exe</PaketExePath>
+
+      <!-- no windows, try native paket as default,  root => tool => proj style => mono paket => bootstrpper => global -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketRootPath)paket') ">$(PaketRootPath)paket</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketToolsPath)paket') ">$(PaketToolsPath)paket</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket</PaketExePath>
+
+      <!-- no windows, try mono paket -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
+
+      <!-- no windows, try bootstrapper -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketBootStrapperExeDir)') ">$(PaketBootStrapperExeDir)paket.exe</PaketExePath>
+
+      <!-- no windows, try global native paket -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' ">paket</PaketExePath>
+
+      <_PaketExeExtension>$([System.IO.Path]::GetExtension("$(PaketExePath)"))</_PaketExeExtension>
+      <InternalPaketCommand Condition=" '$(InternalPaketCommand)' == '' AND '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</InternalPaketCommand>
+      <InternalPaketCommand Condition=" '$(InternalPaketCommand)' == '' AND '$(OS)' != 'Windows_NT' AND '$(_PaketExeExtension)' == '.exe' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</InternalPaketCommand>
+      <InternalPaketCommand Condition=" '$(InternalPaketCommand)' == '' ">"$(PaketExePath)"</InternalPaketCommand>
+
+    </PropertyGroup>
+
+    <!-- The way to get a property to be available outside the target is to use this task. -->
+    <CreateProperty Value="$(InternalPaketCommand)">
+      <Output TaskParameter="Value" PropertyName="PaketCommand"/>
+    </CreateProperty>
+
+  </Target>
+
   <Target Name="PaketBootstrapping" Condition="Exists('$(PaketToolsPath)paket.bootstrapper.proj')">
     <MSBuild Projects="$(PaketToolsPath)paket.bootstrapper.proj" Targets="Restore" />
   </Target>
@@ -82,7 +101,7 @@
   <!-- Official workaround for https://docs.microsoft.com/en-us/visualstudio/msbuild/getfilehash-task?view=vs-2019 -->
   <UsingTask TaskName="Microsoft.Build.Tasks.GetFileHash" AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(DetectedMSBuildVersion)' &lt; '16.0.360' " />
   <UsingTask TaskName="Microsoft.Build.Tasks.VerifyFileHash" AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(DetectedMSBuildVersion)' &lt; '16.0.360' " />
-  <Target Name="PaketRestore" Condition="'$(PaketRestoreDisabled)' != 'True'" BeforeTargets="_GenerateDotnetCliToolReferenceSpecs;_GenerateProjectRestoreGraphPerFramework;_GenerateRestoreGraphWalkPerFramework;CollectPackageReferences" DependsOnTargets="PaketBootstrapping">
+  <Target Name="PaketRestore" Condition="'$(PaketRestoreDisabled)' != 'True'" BeforeTargets="_GenerateDotnetCliToolReferenceSpecs;_GenerateProjectRestoreGraphPerFramework;_GenerateRestoreGraphWalkPerFramework;CollectPackageReferences" DependsOnTargets="SetPaketCommand;PaketBootstrapping">
 
     <!-- Step 1 Check if lockfile is properly restored (if the hash of the lockfile and the cache-file match) -->
     <PropertyGroup>
@@ -247,7 +266,7 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="PaketOverrideNuspec" AfterTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(PaketIntermediateOutputPath)/$(MSBuildProjectFile).references')" >
+  <Target Name="PaketOverrideNuspec" DependsOnTargets="SetPaketCommand" AfterTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(PaketIntermediateOutputPath)/$(MSBuildProjectFile).references')" >
     <ItemGroup>
       <_NuspecFilesNewLocation Include="$(PaketIntermediateOutputPath)\$(Configuration)\*.nuspec"/>
       <MSBuildMajorVersion Include="$(DetectedMSBuildVersion.Replace(`-`, `.`).Split(`.`)[0])" />

--- a/README.md
+++ b/README.md
@@ -172,6 +172,39 @@ Router.navigate("users", HistoryMode.PushState)
 Router.navigate("users", HistoryMode.ReplaceState)
 ```
 
+### Generating links
+
+In addition to `Router.navigate(...)` you can also use the `Router.format(...)` if you only need to generate the string that can be used to set the `href` property of a link.
+
+The function `Router.format` has a similar general syntax as `Router.navigate`:
+```
+Router.format(segment1, segment2, ..., segmentN, [query string parameters])
+```
+Examples of the generated paths:
+```fs
+Router.format("users") => "#/users"
+Router.format("users", "about") => "#/users/about"
+Router.format("users", 1) => "#/users/1"
+Router.format("users", 1, "details") => "#/users/1/details"
+```
+Examples of generated paths with query string parameters
+```fs
+Router.format("users", [ "id", 1 ]) => "#/user?id=1"
+Router.format("users", [ "name", "john"; "married", "false" ]) => "#/users?name=john&married=false"
+// paramters are encoded automatically
+Router.format("search", [ "q", "whats up" ]) => @"#/search?q=whats%20up"
+```
+
+Example of usage:
+```fs
+Html.a [
+    prop.href (Router.format("users", ["id", 10]))
+    prop.text "Single User link"
+]
+```
+
+### Demo application
+
 Here is a full example in an Elmish program.
 
 ```fs
@@ -197,9 +230,16 @@ let render state dispatch =
     let currentPage =
         match state.CurrentUrl with
         | [ ] ->
-            Html.button [
-                prop.text "Navigate to users"
-                prop.onClick (fun _ -> dispatch NavigateToUsers)
+            Html.div [
+                Html.h1 "Home"
+                Html.button [
+                    prop.text "Navigate to users"
+                    prop.onClick (fun _ -> dispatch NavigateToUsers)
+                ]
+                Html.a [
+                    prop.href (Router.format("users"))
+                    prop.text "Users link"
+                ]
             ]
         | [ "users" ] ->
             Html.div [
@@ -207,6 +247,10 @@ let render state dispatch =
                 Html.button [
                     prop.text "Navigate to User(10)"
                     prop.onClick (fun _ -> dispatch (NavigateToUser 10))
+                ]
+                Html.a [
+                    prop.href (Router.format("users", ["id", 10]))
+                    prop.text "Single User link"
                 ]
             ]
 

--- a/demo/App.fs
+++ b/demo/App.fs
@@ -29,17 +29,26 @@ let render state dispatch =
     let currentPage =
         match state.CurrentUrl with
         | [ ] ->
-            Html.button [
-                prop.text "Users"
-                prop.onClick (fun _ -> dispatch NavigateUsers)
+            Html.div [
+                Html.button [
+                    prop.text "Users"
+                    prop.onClick (fun _ -> dispatch NavigateUsers)
+                ]
+                Html.a [
+                    prop.href (Router.format("users"))
+                    prop.text "Users link"
+                ]
             ]
-
         | [ "users" ] ->
             Html.div [
                 prop.children [
                     Html.button [
                         prop.text "Single User"
                         prop.onClick (fun _ -> dispatch (NavigateToUser 10))
+                    ]
+                    Html.a [
+                        prop.href (Router.format("users", ["id", 10]))
+                        prop.text "Single User link"
                     ]
                 ]
             ]

--- a/src/Router.fs
+++ b/src/Router.fs
@@ -374,6 +374,83 @@ type Router =
     static member navigate(segment1: string, value1: int, value2: int, segment2: string, mode) : Cmd<_> =
         Router.nav [segment1; string value1; string value2; segment2 ] mode
 
+    static member format([<ParamArray>] xs: string array) =
+        Router.encodeParts (List.ofArray xs)
+    static member format(segment: string, queryString) : string =
+        Router.encodeParts [ segment + Router.encodeQueryString queryString ]
+    static member format(segment: string, queryString) : string =
+        Router.encodeParts [ segment + Router.encodeQueryStringInts queryString ]
+    static member format(segment1: string, segment2: string, queryString) : string =
+        Router.encodeParts [ segment1; segment2 + Router.encodeQueryString queryString ]
+    static member format(segment1: string, segment2: string, queryString) : string =
+        Router.encodeParts [ segment1; segment2 + Router.encodeQueryStringInts queryString ]
+    static member format(segment1: string, segment2: string, segment3:int, queryString) : string =
+        Router.encodeParts [ segment1; segment2; string segment3 + Router.encodeQueryString queryString ]
+    static member format(segment1: string, segment2: string, segment3:int, queryString) : string =
+        Router.encodeParts [ segment1; segment2; string segment3 + Router.encodeQueryStringInts queryString ]
+    static member format(segment1: string, segment2: string, segment3:string, queryString) : string =
+        Router.encodeParts [ segment1; segment2; segment3 + Router.encodeQueryString queryString ]
+    static member format(segment1: string, segment2: string, segment3:string, queryString) : string =
+        Router.encodeParts [ segment1; segment2; segment3 + Router.encodeQueryStringInts queryString ]
+    static member format(segment1: string, segment2: int, segment3:string, queryString) : string =
+        Router.encodeParts [ segment1; string segment2; segment3 + Router.encodeQueryString queryString ]
+    static member format(segment1: string, segment2: int, segment3:string, queryString) : string =
+        Router.encodeParts [ segment1; string segment2; segment3 + Router.encodeQueryStringInts queryString ]
+    static member format(segment1: string, segment2: string, segment3:string, segment4: string, queryString) : string =
+        Router.encodeParts [ segment1; segment2; segment3; segment4 + Router.encodeQueryString queryString ]
+    static member format(segment1: string, segment2: string, segment3:string, segment4: string, queryString) : string =
+        Router.encodeParts [ segment1; segment2; segment3; segment4 + Router.encodeQueryStringInts queryString ]
+    static member format(segment1: string, segment2: string, segment3:string, segment4: string, segment5, queryString) : string =
+        Router.encodeParts [ segment1; segment2; segment3; segment4; segment5 + Router.encodeQueryString queryString ]
+    static member format(segment1: string, segment2: string, segment3:string, segment4: string, segment5, queryString) : string =
+        Router.encodeParts [ segment1; segment2; segment3; segment4; segment5 + Router.encodeQueryStringInts queryString ]
+    static member format(segment1: string, segment2: int, segment3:string, segment4: string, queryString) : string =
+        Router.encodeParts [ segment1; string segment2; segment3; segment4 + Router.encodeQueryString queryString ]
+    static member format(segment1: string, segment2: int, segment3:string, segment4: string, queryString) : string =
+        Router.encodeParts [ segment1; string segment2; segment3; segment4 + Router.encodeQueryStringInts queryString ]
+    static member format(segment1: string, segment2: int, segment3:int, segment4: string, queryString) : string =
+        Router.encodeParts [ segment1; string segment2; string segment3; segment4 + Router.encodeQueryString queryString ]
+    static member format(segment1: string, segment2: int, segment3:int, segment4: string, queryString) : string =
+        Router.encodeParts [ segment1; string segment2; string segment3; segment4 + Router.encodeQueryStringInts queryString ]
+    static member format(segment1: string, segment2: int, segment3:int, segment4: string, segment5: string, segment6, queryString) : string =
+        Router.encodeParts [ segment1; string segment2; string segment3; segment4; segment5; segment6 + Router.encodeQueryString queryString ]
+    static member format(segment1: string, segment2: int, segment3:int, segment4: string, segment5: string, segment6, queryString) : string =
+        Router.encodeParts [ segment1; string segment2; string segment3; segment4; segment5; segment6 + Router.encodeQueryStringInts queryString ]
+    static member format(segment1: string, segment2: int, segment3:int, segment4: int, segment5: string, queryString) : string =
+        Router.encodeParts [ segment1; string segment2; string segment3; string segment4; segment5 + Router.encodeQueryString queryString ]
+    static member format(segment1: string, segment2: int, segment3:int, segment4: int, segment5: string, queryString) : string =
+        Router.encodeParts [ segment1; string segment2; string segment3; string segment4; segment5 + Router.encodeQueryStringInts queryString ]
+    static member format(segment1: string, segment2: int, segment3:string, segment4: int, segment5: string, queryString) : string =
+        Router.encodeParts [ segment1; string segment2; segment3; string segment4; segment5 + Router.encodeQueryString queryString ]
+    static member format(segment1: string, segment2: int, segment3:string, segment4: int, segment5: string, queryString) : string =
+        Router.encodeParts [ segment1; string segment2; segment3; string segment4; segment5 + Router.encodeQueryStringInts queryString ]
+    static member format(segment1: string, segment2: int, segment3:string, segment4: string, segment5, queryString) : string =
+        Router.encodeParts [ segment1; string segment2; segment3; segment4; segment5 + Router.encodeQueryString queryString ]
+    static member format(segment1: string, segment2: int, segment3:string, segment4: string, segment5, queryString) : string =
+        Router.encodeParts [ segment1; string segment2; segment3; segment4; segment5 + Router.encodeQueryStringInts queryString ]
+    static member format(fullPath: string) : string =
+        Router.encodeParts [ fullPath ]
+    static member format(segment: string, value: int) : string =
+        Router.encodeParts [segment; string value ]
+    static member format(segment1: string, value1: int, value2: int) : string =
+        Router.encodeParts [segment1; string value1; string value2 ]
+    static member format(segment1: string, segment2: string, value1: int) : string =
+        Router.encodeParts [segment1; segment2; string value1 ]
+    static member format(segment1: string, value1: int, segment2: string) : string =
+        Router.encodeParts [segment1; string value1; segment2 ]
+    static member format(segment1: string, value1: int, segment2: string, value2: int) : string =
+        Router.encodeParts [segment1; string value1; segment2; string value2 ]
+    static member format(segment1: string, value1: int, segment2: string, value2: int, segment3: string) : string =
+        Router.encodeParts [segment1; string value1; segment2; string value2; segment3 ]
+    static member format(segment1: string, value1: int, segment2: string, value2: int, segment3: string, segment4: string) : string =
+        Router.encodeParts [segment1; string value1; segment2; string value2; segment3; segment4 ]
+    static member format(segment1: string, value1: int, segment2: string, value2: int, segment3: string, value3: int) : string =
+        Router.encodeParts [segment1; string value1; segment2; string value2; segment3; string value3 ]
+    static member format(segment1: string, value1: int, value2: int, value3: int) : string =
+        Router.encodeParts [segment1; string value1; string value2; string value3 ]
+    static member format(segment1: string, value1: int, value2: int, segment2: string) : string =
+        Router.encodeParts [segment1; string value1; string value2; segment2 ]
+
 module Route =
     let (|Int|_|) (input: string) =
         match Int32.TryParse input with

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -195,10 +195,6 @@ let routerTests =
                 [ "users" + Router.encodeQueryString [ ] ], "/users"
             ]
             |> List.iter (fun (input, output) -> Expect.equal (Router.encodeParts input) output "They are equal")
-
-        testCase "format works" <| fun _ ->
-            Router.routeMode <- RouteMode.Hash
-            Expect.equal (Router.format ["home"]) "#/home" "They are equal"
     ]
 
 [<EntryPoint>]

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -195,6 +195,10 @@ let routerTests =
                 [ "users" + Router.encodeQueryString [ ] ], "/users"
             ]
             |> List.iter (fun (input, output) -> Expect.equal (Router.encodeParts input) output "They are equal")
+
+        testCase "format works" <| fun _ ->
+            Router.routeMode <- RouteMode.Hash
+            Expect.equal (Router.format ["home"]) "#/home" "They are equal"
     ]
 
 [<EntryPoint>]


### PR DESCRIPTION
Fixes: #9 

No extra tests added since the implementation just re-use `encodeParts` which was already covered.

Not sure why the `Paket.Restore.targets` changed, I guess I might have had a newer version of paket.