### PR TITLE
fix IE: use hashchange event instead, popstate is not supported

### DIFF
--- a/src/Router.fs
+++ b/src/Router.fs
@@ -115,6 +115,9 @@ module internal Router =
     [<Emit("new URLSearchParams($0)")>]
     let createUrlSearchParams (queryString: string) : IUrlSearchParamters = jsNative
 
+    [<Emit("window.navigator.userAgent")>]
+    let navigatorUserAgent : string = jsNative
+
 type RouterProperties = {
     urlChanged: string list -> unit
     application: ReactElement
@@ -141,8 +144,15 @@ type RouterComponent(props: RouterProperties)  =
 
         // register global route mode
         Router.routeMode <- props.routeMode
+
         // listen to path changes
-        window.addEventListener("popstate", unbox onChange)
+        if Router.navigatorUserAgent.Contains "Trident" ||
+           Router.navigatorUserAgent.Contains "MSIE" then
+            window.addEventListener("hashchange", unbox onChange)
+        else
+            window.addEventListener("popstate", unbox onChange)
+
+
         // listen to custom navigation events published by `Router.navigate()`
         window.addEventListener(Router.customNavigationEvent, unbox onChange)
 


### PR DESCRIPTION
Hey Zaid,

1.8.0 broke IE compatibility by [removing the hashchange event][hc]. Maybe with a useragent check like this we could bring it back?

[hc]: https://github.com/Zaid-Ajaj/Feliz.Router/commit/87d1caf72335a8a30ab60f58719a9518a2d9abf7#diff-3692c653a8c0efbced7c61546cf3ae3dL147