### PR TITLE
Fix navigation on page

### DIFF
--- a/src/Router.fs
+++ b/src/Router.fs
@@ -127,8 +127,8 @@ type RouterComponent(props: RouterProperties)  =
 
     override this.componentDidMount() =
         let onChange (ev: _) =
-            match window.location.hash with
-            | "" when props.routeMode = RouteMode.Path -> window.location.pathname + window.location.search
+            match props.routeMode with
+            | RouteMode.Path -> window.location.pathname + window.location.search
             | _ -> window.location.hash
             |> fun path -> Router.urlSegments path props.routeMode
             |> this.props.urlChanged


### PR DESCRIPTION
Hi 👋 , thanks for the great library! As well as all your others.

I was having an issue with being able to use a fragment to navigate to a location on a page in path mode. For instance, if I tried to navigate to https://github.com/Zaid-Ajaj/Feliz.Router#installation using path mode only `[installation]` would be in the UrlChanged event instead of `[Feliz.Router]`.

I think this can be fixed by just matching on the path mode instead of the window hash. A working example using this fork is here: https://andrewmeier.dev/win-dev (can click links in table of contents)