### PR TITLE
Update dependencies

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -7,7 +7,7 @@ group Main
     nuget Fable.SimpleJson
     nuget Feliz
     nuget Feliz.UseListener
-    nuget FSharp.Core lowest_matching: true
+    nuget FSharp.Core
     nuget Fable.Core
     nuget Fable.Elmish.React
 

--- a/paket.lock
+++ b/paket.lock
@@ -7,12 +7,12 @@ NUGET
     Fable.Browser.Blob (1.1) - restriction: >= netstandard2.0
       Fable.Core (>= 3.0) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.6.2) - restriction: >= netstandard2.0
-    Fable.Browser.Dom (2.0.1) - restriction: >= netstandard2.0
+    Fable.Browser.Dom (2.1) - restriction: >= netstandard2.0
       Fable.Browser.Blob (>= 1.1) - restriction: >= netstandard2.0
       Fable.Browser.Event (>= 1.2.1) - restriction: >= netstandard2.0
       Fable.Browser.WebStorage (>= 1.0) - restriction: >= netstandard2.0
       Fable.Core (>= 3.0) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
     Fable.Browser.Event (1.2.1) - restriction: >= netstandard2.0
       Fable.Core (>= 3.0) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
@@ -36,23 +36,23 @@ NUGET
     Fable.Parsimmon (4.1) - restriction: >= netstandard2.0
       Fable.Core (>= 3.0) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.6.2) - restriction: >= netstandard2.0
-    Fable.React (6.2) - restriction: >= netstandard2.0
-      Fable.Browser.Dom (>= 1.0) - restriction: >= netstandard2.0
+    Fable.React (7.0.1) - restriction: >= netstandard2.0
+      Fable.Browser.Dom (>= 2.0.1) - restriction: >= netstandard2.0
       Fable.Core (>= 3.1.5) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.7.1) - restriction: >= netstandard2.0
     Fable.SimpleJson (3.11)
       Fable.Core (>= 3.1.5) - restriction: >= netstandard2.0
       Fable.Parsimmon (>= 4.0) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
-    Feliz (1.5)
+    Feliz (1.13.1)
       Fable.Core (>= 3.1.5) - restriction: >= netstandard2.0
-      Fable.React (>= 6.0) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
-    Feliz.UseListener (0.6)
+      Fable.React (>= 7.0.1) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
+    Feliz.UseListener (0.6.1)
       Fable.Core (>= 3.1.5 < 4.0)
-      Feliz (>= 1.5 < 2.0)
-      FSharp.Core (>= 4.7 < 5.0)
-    FSharp.Core (4.7)
+      Feliz (>= 1.13.1 < 2.0)
+      FSharp.Core (>= 4.7.2 < 5.0)
+    FSharp.Core (4.7.2)
     Microsoft.NETCore.Platforms (3.1.2) - restriction: || (&& (>= net45) (< netstandard1.3) (>= netstandard1.6)) (&& (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (>= net46) (< netstandard1.4) (>= netstandard1.6)) (&& (>= netcoreapp2.0) (< netstandard2.0)) (&& (>= netcoreapp5.0) (< netstandard1.2)) (&& (>= netcoreapp5.0) (< netstandard1.3)) (&& (>= netcoreapp5.0) (< netstandard1.4)) (&& (>= netcoreapp5.0) (< netstandard1.5)) (&& (>= netcoreapp5.0) (< netstandard2.0)) (&& (< netstandard1.0) (>= netstandard1.6) (< portable-net45+win8)) (&& (< netstandard1.0) (>= netstandard1.6) (>= win8)) (&& (< netstandard1.0) (>= netstandard1.6) (< win8)) (&& (< netstandard1.3) (>= netstandard1.6) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0)) (&& (>= netstandard1.6) (< portable-net45+win8+wpa81)) (&& (>= netstandard1.6) (>= uap10.1)) (&& (>= netstandard1.6) (>= wp8))
     Microsoft.NETCore.Targets (3.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.6) (< win8)) (&& (>= netcoreapp5.0) (< netstandard1.2)) (&& (>= netcoreapp5.0) (< netstandard1.3)) (&& (>= netcoreapp5.0) (< netstandard1.4)) (&& (>= netcoreapp5.0) (< netstandard1.5)) (&& (>= netcoreapp5.0) (< netstandard2.0)) (&& (>= netcoreapp5.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.1) (>= netstandard1.6) (>= uap10.0) (< win8)) (&& (< netstandard1.3) (>= netstandard1.6) (>= uap10.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0) (< win8) (< wpa81)) (&& (>= netstandard1.6) (< portable-net45+win8+wpa81))
     Microsoft.Win32.Primitives (4.3) - restriction: || (&& (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (>= net46) (< netstandard1.4) (>= netstandard1.6)) (&& (< netstandard1.5) (>= netstandard1.6) (>= uap10.0))
@@ -600,7 +600,7 @@ NUGET
       System.Reflection.TypeExtensions (>= 4.3) - restriction: && (< net461) (>= netstandard2.0)
       System.Runtime.Loader (>= 4.0) - restriction: && (< net461) (>= netstandard2.0)
     FSharp.Core (4.7.2) - restriction: >= netstandard2.0
-    McMaster.NETCore.Plugins (1.3) - restriction: >= netcoreapp2.0
+    McMaster.NETCore.Plugins (1.3.1) - restriction: >= netcoreapp2.0
       Microsoft.DotNet.PlatformAbstractions (>= 3.1) - restriction: >= netcoreapp2.0
       Microsoft.Extensions.DependencyModel (>= 3.1) - restriction: >= netcoreapp2.0
       System.Text.Json (>= 4.7) - restriction: && (>= netcoreapp2.0) (< netcoreapp3.0)
@@ -979,9 +979,9 @@ NUGET
       System.Runtime (>= 4.3)
       System.Runtime.Extensions (>= 4.3)
       System.Threading (>= 4.3)
-    System.Formats.Asn1 (5.0.0-preview.7.20364.11)
-      System.Buffers (>= 4.5)
-      System.Memory (>= 4.5.3)
+    System.Formats.Asn1 (5.0.0-preview.8.20407.11)
+      System.Buffers (>= 4.5.1)
+      System.Memory (>= 4.5.4)
     System.Globalization (4.3)
       Microsoft.NETCore.Platforms (>= 1.1)
       Microsoft.NETCore.Targets (>= 1.1)
@@ -1095,12 +1095,12 @@ NUGET
       System.Runtime (>= 4.3)
     System.Security.AccessControl (4.7)
       System.Security.Principal.Windows (>= 4.7)
-    System.Security.Cryptography.Cng (5.0.0-preview.7.20364.11)
-    System.Security.Cryptography.Pkcs (5.0.0-preview.7.20364.11)
-      System.Buffers (>= 4.5)
-      System.Formats.Asn1 (>= 5.0.0-preview.7.20364.11)
-      System.Memory (>= 4.5.3)
-      System.Security.Cryptography.Cng (>= 5.0.0-preview.7.20364.11)
+    System.Security.Cryptography.Cng (5.0.0-preview.8.20407.11)
+    System.Security.Cryptography.Pkcs (5.0.0-preview.8.20407.11)
+      System.Buffers (>= 4.5.1)
+      System.Formats.Asn1 (>= 5.0.0-preview.8.20407.11)
+      System.Memory (>= 4.5.4)
+      System.Security.Cryptography.Cng (>= 5.0.0-preview.8.20407.11)
     System.Security.Cryptography.ProtectedData (4.7)
       System.Memory (>= 4.5.3)
     System.Security.Permissions (4.7)


### PR DESCRIPTION
Updates dependencies so that `Feliz >= 1.13.1` is used to ensure [this issue](https://github.com/Zaid-Ajaj/Feliz/issues/252) doesn't pop up when people update the package.

Might want to also consider just unlisting version 3.1.0 so people with `FSharp.Core` pinned to `4.7.0` can't update to that version. 