### PR TITLE
Update readme on useState

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ let parseUrl = function
 
 [<ReactComponent>]
 static member Router() =
-    let (pageUrl, updateUrl) = React.useState(parseUrl(Router.currentUrl()))
+    let (pageUrl, updateUrl) = React.useState(Router.currentUrl >> parseUrl)
     let currentPage =
         match pageUrl with
         | Home -> Html.h1 "Home"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ open Feliz.Router
 
 [<ReactComponent>]
 let Router() =
-    let (currentUrl, updateUrl) = React.useState(Router.currentUrl())
+    let (currentUrl, updateUrl) = React.useState(Router.currentUrl)
     React.router [
         router.onUrlChanged updateUrl
         router.children [
@@ -133,7 +133,7 @@ let parseUrl = function
 
 [<ReactComponent>]
 static member Router() =
-    let (pageUrl, updateUrl) = React.useState(parseUrl(Router.currentUrl()))
+    let (pageUrl, updateUrl) = React.useState(parseUrl(Router.currentUrl))
     let currentPage =
         match pageUrl with
         | Home -> Html.h1 "Home"

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ let parseUrl = function
 
 [<ReactComponent>]
 static member Router() =
-    let (pageUrl, updateUrl) = React.useState(parseUrl(Router.currentUrl))
+    let (pageUrl, updateUrl) = React.useState(parseUrl(Router.currentUrl()))
     let currentPage =
         match pageUrl with
         | Home -> Html.h1 "Home"


### PR DESCRIPTION
### Problem
I noticed that in the docs the useState is as follows
> let (currentUrl, updateUrl) = Feliz.React.useState(Feliz.Router.Router.currentUrl())

However there is a type mismatch with the useState, since it requires a `unit -> 'T`, resulting in
> let (currentUrl, updateUrl) = Feliz.React.useState(Feliz.Router.Router.currentUrl)

### Pictures

![Screenshot from 2021-09-25 21-11-51](https://user-images.githubusercontent.com/14153897/134789029-7ce06487-e7c0-403b-a666-883c9ee3b9d6.png)
![Screenshot from 2021-09-25 21-14-02](https://user-images.githubusercontent.com/14153897/134789030-658e5571-3e12-4b22-8a7c-4715a497700e.png)
![Screenshot from 2021-09-25 21-14-28](https://user-images.githubusercontent.com/14153897/134789031-ac52bd86-63a7-4d9b-a360-3b8475bae8e0.png)


