### PR TITLE
Fix for "Cannot GET /users" error

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,8 @@ module.exports = function (evn, argv) {
         },
         devServer: {
             contentBase: './public',
-            port: 8080
+            port: 8080,
+            historyApiFallback: true
         },
         module: {
             rules: [


### PR DESCRIPTION
Running demo locally and navigating to "http://localhost:8080/users" was causing "Cannot GET /users" error similar to what is described in [thread on StackOverflow](https://stackoverflow.com/questions/34358334/react-router-error-cannot-get-page-name). Change from PR fix this error.